### PR TITLE
[fix] Posts were not being matched correctly

### DIFF
--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -95,7 +95,7 @@ export default class Bot
         // Checks if the video we're posting has already been posted
         // A previous image post with no caption and a previous video with no
         // caption should also cause this check to fail
-        if (text === bskyText && postType === 'app.bsky.embed.video') // postType confirms the matching post is also a video
+        if ((text as string).trim() === (bskyText as string).trim() && postType === 'app.bsky.embed.video') // postType confirms the matching post is also a video
         {
           // TODO: not a fail safe check but the best that works for now
           var postHeight = (bskyRecord as any)["embed"]["aspectRatio"]["height"];
@@ -270,7 +270,7 @@ export default class Bot
 
         // Checks if the image or text post has already been posted
         // A previous image post with no caption should cause this to fail
-        if (text === bskyText) // Check if the text we are trying to post has already been posted in the last postNum posts, or is empty. Might change empty conditional if I get images working.  
+        if ((text as string).trim() === (bskyText as string).trim()) // Check if the text we are trying to post has already been posted in the last postNum posts, or is empty. Might change empty conditional if I get images working.  
         { 
           if (postType === 'app.bsky.embed.images') {
             var postAlt = (bskyRecord as any)["embed"]["images"][0]["alt"];

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -105,7 +105,7 @@ export default class Bot
           
           if (postHeight != videoHeight && postWidth != videoWidth) {
             console.log('video texts matched but height and width did not');
-            break;
+            continue;
           }
 
           console.log("failed on case " + i + " in video post");
@@ -280,7 +280,7 @@ export default class Bot
             // that are both too long for bluesky (i.e same alt text)
             if (postAlt != imgAlt) {
               console.log('image post text matched but alts did not');
-              break;
+              continue;
             }
           }
 


### PR DESCRIPTION
This PR addresses two issues that were arising during post matching: whitespace at the start/end of text was causing matches to fail in situations they shouldn't, and not all non-caption posts were being checked against the current post. 

The following changes were made:
- used trim() to get rid of whitespace around string when comparing current post's text with previous posts' text
- replace break with continue to prevent exiting comparison loop