### PR TITLE
[fix] Videos longer than 60 seconds posted multiple times

### DIFF
--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -105,6 +105,10 @@ export default class Bot
           
           if (postHeight != videoHeight && postWidth != videoWidth) {
             console.log('video texts matched but height and width did not');
+            console.log('post text: ', text);
+            console.log('bsky text: ', bskyText);
+            console.log('post height and width: ', videoHeight, ' ', videoWidth);
+            console.log('bsky height and width: ', postHeight, ' ', postWidth);
             continue;
           }
 
@@ -280,6 +284,8 @@ export default class Bot
             // that are both too long for bluesky (i.e same alt text)
             if (postAlt != imgAlt) {
               console.log('image post text matched but alts did not');
+              console.log('post text: ', text);
+              console.log('bsky text: ', bskyText);
               console.log('post alt: ', imgAlt);
               console.log('bsky alt: ', postAlt);
               continue;

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -274,12 +274,14 @@ export default class Bot
         { 
           if (postType === 'app.bsky.embed.images') {
             var postAlt = (bskyRecord as any)["embed"]["images"][0]["alt"];
-            var imgAlt = alt.split('!^&')[0].replace('None', '');
+            var imgAlt = alts[0].replace('None', '');
             
             // TODO: this is not fail safe if there is a case of two videos with no captions
             // that are both too long for bluesky (i.e same alt text)
             if (postAlt != imgAlt) {
               console.log('image post text matched but alts did not');
+              console.log('post alt: ', imgAlt);
+              console.log('bsky alt: ', postAlt);
               continue;
             }
           }


### PR DESCRIPTION
This PR address the issue where videos longer than 60 seconds that are posted as images with an alt were being reposted multiple times and incorrectly passing the check which determined if they'd been posted already.

The following changes were made:
- fixed incorrect alt comparisons
- added some logging for future comparisons