### PR TITLE
[fix] Remove videos from mixed media posts

### DIFF
--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -207,7 +207,7 @@ export default class Bot
 
       for (var i = 0; i < 4; i++)
       {
-        if (urls[i] != "None")
+        if (urls[i] != "None" && urls[i].slice(-3) != "mp4")
         {
           var response = await axios.get(urls[i], { responseType: 'arraybuffer'});
           var buffer = Buffer.from(response.data, "utf-8");


### PR DESCRIPTION
This PR resolves an error when trying to upload mixed media (contains both images and videos) posts. It removes the videos from the post and only posts the images.