### PR TITLE
[fix] Deleted posts led to reposts

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - main
-  # schedule:
-  #   - cron: "*/60 * * * *"
+  schedule:
+    - cron: "*/30 * * * *"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -79,7 +79,7 @@ export default class Bot
     text: string | (Partial<AppBskyFeedPost.Record> & Omit<AppBskyFeedPost.Record, "createdAt">)
   ): Promise<void> {
 
-    var postNum = 20; // Specify the number of recent posts to compare from the logged in user's feed.
+    var postNum = 25; // Specify the number of recent posts to compare from the logged in user's feed.
     var bskyFeedAwait = await this.userAgent.app.bsky.feed.getAuthorFeed({actor: "notmapleleafs.bsky.social", limit: postNum,}); // Get a defined number + 2 of most recent posts from the logged in user's feed.
     var bskyFeed = bskyFeedAwait["data"]["feed"]; // Filter down the await values so we are only looking at the feeds.
     for (let i = 0; i < bskyFeed.length; i++) // Consider all collected posts.
@@ -240,7 +240,7 @@ export default class Bot
         }
       }
 
-      var postNum = 20; // Specify the number of recent posts to compare from the logged in user's feed.
+      var postNum = 25; // Specify the number of recent posts to compare from the logged in user's feed.
       var bskyFeedAwait = await this.userAgent.app.bsky.feed.getAuthorFeed({actor: "notmapleleafs.bsky.social", limit: postNum,}); // Get a defined number + 2 of most recent posts from the logged in user's feed.
       var bskyFeed = bskyFeedAwait["data"]["feed"]; // Filter down the await values so we are only looking at the feeds.
       var bskyFeed0 = bskyFeed[0]; // Select post 0, the most recent post made by this user.


### PR DESCRIPTION
This PR fixes the issue where posts posted to Bluesky were removed from the original Twitter account. In cases where these posts overlapped with last 20 posts retrieved from Bluesky, it caused the older posts from Twitter to be reposted since the timelines were out of sync.